### PR TITLE
Add REST routes for getting fonts by ID, name

### DIFF
--- a/cmd/fontman/main.go
+++ b/cmd/fontman/main.go
@@ -2,16 +2,17 @@ package main
 
 import (
 	"fontman/registry/pkg/controller"
+	"log"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/mattn/go-sqlite3"
-	"log"
 )
 
 /*
 	Given a list of controllers, initialize all the routes.
 */
-func setupControllers(controllers []controller.Controller, app *fiber.Router, db *sqlx.DB) {
+func setupControllers(controllers []controller.Controller, app fiber.Router, db *sqlx.DB) {
 	for _, controller := range controllers {
 		controller.Setup(app, db)
 	}
@@ -29,7 +30,7 @@ func main() {
 	setupControllers([]controller.Controller{
 		&controller.FontController{},
 		&controller.UserController{},
-	}, &api, db)
+	}, api, db)
 
 	app.Listen(":8080")
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -6,5 +6,5 @@ import (
 )
 
 type Controller interface {
-	Setup(app *fiber.Router, db *sqlx.DB)
+	Setup(app fiber.Router, db *sqlx.DB)
 }

--- a/pkg/controller/font.go
+++ b/pkg/controller/font.go
@@ -1,8 +1,10 @@
 package controller
 
 import (
-	"fmt"
+	"fontman/registry/pkg/service"
+
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -10,6 +12,34 @@ type FontController struct {
 	Controller
 }
 
-func (f *FontController) Setup(app *fiber.Router, db *sqlx.DB) {
-	fmt.Println("setup font controller")
+func (f *FontController) Setup(app fiber.Router, db *sqlx.DB) {
+	font := app.Group("/font")
+
+	font.Get("/:id", func(ctx *fiber.Ctx) error {
+		return GetFont(ctx, db)
+	})
+
+	font.Post("/", func(ctx *fiber.Ctx) error {
+		return UploadFont(ctx, db)
+	})
+}
+
+func GetFont(ctx *fiber.Ctx, client *sqlx.DB) error {
+	id := ctx.Params("id")
+	fontId := uuid.MustParse(id)
+
+	font, err := service.GetFont(client, fontId)
+
+	if err != nil {
+		return err
+	}
+
+	return ctx.JSON(fiber.Map{
+		"id":   font.Id,
+		"name": font.Name,
+	})
+}
+
+func UploadFont(ctx *fiber.Ctx, client *sqlx.DB) error {
+	return ctx.SendString("upload font")
 }

--- a/pkg/controller/font.go
+++ b/pkg/controller/font.go
@@ -16,7 +16,11 @@ func (f *FontController) Setup(app fiber.Router, db *sqlx.DB) {
 	font := app.Group("/font")
 
 	font.Get("/:id", func(ctx *fiber.Ctx) error {
-		return GetFont(ctx, db)
+		return GetFontById(ctx, db)
+	})
+
+	font.Get("/", func(ctx *fiber.Ctx) error {
+		return GetFontsByParam(ctx, db)
 	})
 
 	font.Post("/", func(ctx *fiber.Ctx) error {
@@ -24,11 +28,11 @@ func (f *FontController) Setup(app fiber.Router, db *sqlx.DB) {
 	})
 }
 
-func GetFont(ctx *fiber.Ctx, client *sqlx.DB) error {
+func GetFontById(ctx *fiber.Ctx, client *sqlx.DB) error {
 	id := ctx.Params("id")
 	fontId := uuid.MustParse(id)
 
-	font, err := service.GetFont(client, fontId)
+	font, err := service.GetFontById(client, fontId)
 
 	if err != nil {
 		return err
@@ -38,6 +42,19 @@ func GetFont(ctx *fiber.Ctx, client *sqlx.DB) error {
 		"id":     font.Id,
 		"name":   font.Name,
 		"styles": font.Styles,
+	})
+}
+
+func GetFontsByParam(ctx *fiber.Ctx, client *sqlx.DB) error {
+	name := ctx.Query("name")
+	fonts, err := service.GetFontByName(client, name)
+
+	if err != nil {
+		return err
+	}
+
+	return ctx.JSON(fiber.Map{
+		"fonts": fonts,
 	})
 }
 

--- a/pkg/controller/font.go
+++ b/pkg/controller/font.go
@@ -30,7 +30,11 @@ func (f *FontController) Setup(app fiber.Router, db *sqlx.DB) {
 
 func GetFontById(ctx *fiber.Ctx, client *sqlx.DB) error {
 	id := ctx.Params("id")
-	fontId := uuid.MustParse(id)
+	fontId, idErr := uuid.Parse(id)
+
+	if idErr != nil {
+		return idErr
+	}
 
 	font, err := service.GetFontById(client, fontId)
 

--- a/pkg/controller/font.go
+++ b/pkg/controller/font.go
@@ -35,8 +35,9 @@ func GetFont(ctx *fiber.Ctx, client *sqlx.DB) error {
 	}
 
 	return ctx.JSON(fiber.Map{
-		"id":   font.Id,
-		"name": font.Name,
+		"id":     font.Id,
+		"name":   font.Name,
+		"styles": font.Styles,
 	})
 }
 

--- a/pkg/controller/user.go
+++ b/pkg/controller/user.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/jmoiron/sqlx"
 )
@@ -10,6 +11,6 @@ type UserController struct {
 	Controller
 }
 
-func (u *UserController) Setup(app *fiber.Router, db *sqlx.DB) {
+func (u *UserController) Setup(app fiber.Router, db *sqlx.DB) {
 	fmt.Println("setup user controller")
 }

--- a/pkg/model/font.go
+++ b/pkg/model/font.go
@@ -7,4 +7,5 @@ type Font struct {
 	Name    string    `db:"name"`
 	License string    `db:"license"`
 	Creator string    `db:"creator"`
+	Styles  []*FontStyle
 }

--- a/pkg/model/font.go
+++ b/pkg/model/font.go
@@ -1,11 +1,15 @@
 package model
 
-import "github.com/google/uuid"
+import (
+	"database/sql"
+
+	"github.com/google/uuid"
+)
 
 type Font struct {
-	Id      uuid.UUID `db:"id"`
-	Name    string    `db:"name"`
-	License string    `db:"license"`
-	Creator string    `db:"creator"`
-	Styles  []*FontStyle
+	Id      uuid.UUID      `db:"id" json:"id"`
+	Name    string         `db:"name" json:"name"`
+	License sql.NullString `db:"license" json:"license"`
+	Creator sql.NullString `db:"creator" json:"creator"`
+	Styles  []*FontStyle   `json:"styles"`
 }

--- a/pkg/model/font.go
+++ b/pkg/model/font.go
@@ -3,8 +3,8 @@ package model
 import "github.com/google/uuid"
 
 type Font struct {
-	Id         uuid.UUID `db:"id"`
-	Name       string 	 `db:"name"`
-	License	   string 	 `db:"license"`
-	Creator    string 	 `db:"creator"`
+	Id      uuid.UUID `db:"id"`
+	Name    string    `db:"name"`
+	License string    `db:"license"`
+	Creator string    `db:"creator"`
 }

--- a/pkg/model/style.go
+++ b/pkg/model/style.go
@@ -4,7 +4,7 @@ import "github.com/google/uuid"
 
 type FontStyle struct {
 	Id     uuid.UUID `db:"id"`
-	Family string 	 `db:"family"`
-	Style  string	 `db:"style"`
-	URL    string	 `db:"url"`
+	Family string    `db:"family"`
+	Style  string    `db:"style"`
+	URL    string    `db:"url"`
 }

--- a/pkg/model/style.go
+++ b/pkg/model/style.go
@@ -3,8 +3,8 @@ package model
 import "github.com/google/uuid"
 
 type FontStyle struct {
-	Id     uuid.UUID `db:"id"`
-	Family string    `db:"family"`
-	Type   string    `db:"type"`
-	URL    string    `db:"url"`
+	Id     uuid.UUID `db:"id" json:"-"`
+	Family string    `db:"family" json:"-"`
+	Type   string    `db:"type" json:"type"`
+	URL    string    `db:"url" json:"url"`
 }

--- a/pkg/model/style.go
+++ b/pkg/model/style.go
@@ -5,6 +5,6 @@ import "github.com/google/uuid"
 type FontStyle struct {
 	Id     uuid.UUID `db:"id"`
 	Family string    `db:"family"`
-	Style  string    `db:"style"`
+	Type   string    `db:"type"`
 	URL    string    `db:"url"`
 }

--- a/pkg/repository/font.go
+++ b/pkg/repository/font.go
@@ -7,6 +7,9 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+/**
+ * Get information about a specific font family. Does not include font styles.
+ */
 func GetFontById(client *sqlx.DB, id uuid.UUID) (*model.Font, error) {
 	var font model.Font
 
@@ -22,4 +25,24 @@ func GetFontById(client *sqlx.DB, id uuid.UUID) (*model.Font, error) {
 	}
 
 	return &font, nil
+}
+
+/**
+ * Get all styles for a font family.
+ */
+func GetStylesByFamilyId(client *sqlx.DB, familyId uuid.UUID) ([]*model.FontStyle, error) {
+	var styles []*model.FontStyle
+
+	err := client.Select(&styles, `
+		SELECT *
+		FROM FontStyle f
+		WHERE f.family = ?
+		LIMIT 1
+	`, familyId)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return styles, nil
 }

--- a/pkg/repository/font.go
+++ b/pkg/repository/font.go
@@ -1,19 +1,25 @@
 package repository
 
 import (
-	"github.com/gmisail/fontman/registry/pkg/model"
+	"fontman/registry/pkg/model"
+
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 )
 
-func GetFontById(client *sqlx.DB, id uuid.UUID) model.Font {
+func GetFontById(client *sqlx.DB, id uuid.UUID) (*model.Font, error) {
 	var font model.Font
 
-	err := client.Get(&font, "SELECT * FROM place LIMIT 1")
+	err := client.Get(&font, `
+		SELECT id, name 
+		FROM FontFamily f
+		WHERE f.id = ?
+		LIMIT 1
+	`, id)
 
-	return font
-}
+	if err != nil {
+		return nil, err
+	}
 
-func GetFontByFamily(client *sqlx.DB, family string) model.Font {
-
+	return &font, nil
 }

--- a/pkg/repository/font.go
+++ b/pkg/repository/font.go
@@ -28,6 +28,25 @@ func GetFontById(client *sqlx.DB, id uuid.UUID) (*model.Font, error) {
 }
 
 /**
+ * Return all font families that have the given name.
+ */
+func GetFontsByName(client *sqlx.DB, name string) ([]*model.Font, error) {
+	var fonts []*model.Font
+
+	err := client.Select(&fonts, `
+		SELECT *
+		FROM FontFamily f
+		WHERE f.name = ?
+	`, name)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return fonts, nil
+}
+
+/**
  * Get all styles for a font family.
  */
 func GetStylesByFamilyId(client *sqlx.DB, familyId uuid.UUID) ([]*model.FontStyle, error) {
@@ -37,7 +56,6 @@ func GetStylesByFamilyId(client *sqlx.DB, familyId uuid.UUID) ([]*model.FontStyl
 		SELECT *
 		FROM FontStyle f
 		WHERE f.family = ?
-		LIMIT 1
 	`, familyId)
 
 	if err != nil {

--- a/pkg/service/font.go
+++ b/pkg/service/font.go
@@ -1,7 +1,15 @@
 package service
 
-func GetFont() {
+import (
+	"fontman/registry/pkg/model"
+	"fontman/registry/pkg/repository"
 
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+func GetFont(client *sqlx.DB, id uuid.UUID) (*model.Font, error) {
+	return repository.GetFontById(client, id)
 }
 
 func DeleteFont() {

--- a/pkg/service/font.go
+++ b/pkg/service/font.go
@@ -8,14 +8,27 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+/**
+ * Get a font & its styles by a family ID
+ */
 func GetFont(client *sqlx.DB, id uuid.UUID) (*model.Font, error) {
-	return repository.GetFontById(client, id)
+	font, fontErr := repository.GetFontById(client, id)
+
+	if fontErr != nil {
+		return nil, fontErr
+	}
+
+	styles, styleErr := repository.GetStylesByFamilyId(client, id)
+
+	if styleErr != nil {
+		return nil, styleErr
+	}
+
+	font.Styles = styles
+
+	return font, nil
 }
 
 func DeleteFont() {
-
-}
-
-func GetStylesFromFont(font string, exclude []string) {
 
 }

--- a/pkg/service/font.go
+++ b/pkg/service/font.go
@@ -11,7 +11,7 @@ import (
 /**
  * Get a font & its styles by a family ID
  */
-func GetFont(client *sqlx.DB, id uuid.UUID) (*model.Font, error) {
+func GetFontById(client *sqlx.DB, id uuid.UUID) (*model.Font, error) {
 	font, fontErr := repository.GetFontById(client, id)
 
 	if fontErr != nil {
@@ -27,6 +27,10 @@ func GetFont(client *sqlx.DB, id uuid.UUID) (*model.Font, error) {
 	font.Styles = styles
 
 	return font, nil
+}
+
+func GetFontByName(client *sqlx.DB, name string) ([]*model.Font, error) {
+	return repository.GetFontsByName(client, name)
 }
 
 func DeleteFont() {


### PR DESCRIPTION
This pull request adds two routes: `/api/font/:id` and `/api/font?name='...'`. The first will return all information about
a font and its styles, while the second will lookup a font based on query strings. For now, only 'name' is implemented. The 
latter route will return information about font families, not the font *styles*.  
