### PR TITLE
Implement route for getting fonts with name

### DIFF
--- a/pkg/controller/font.go
+++ b/pkg/controller/font.go
@@ -52,6 +52,12 @@ func GetFontById(ctx *fiber.Ctx, client *sqlx.DB) error {
 
 func GetFontsByParam(ctx *fiber.Ctx, client *sqlx.DB) error {
 	name := ctx.Query("name")
+
+	// no name provided? Send back empty list
+	if len(name) == 0 {
+		return ctx.JSON(fiber.Map{"fonts": []*model.Font{}})
+	}
+
 	fonts, err := service.GetFontByName(client, name)
 
 	if err != nil {

--- a/pkg/repository/font.go
+++ b/pkg/repository/font.go
@@ -31,13 +31,13 @@ func GetFontById(client *sqlx.DB, id uuid.UUID) (*model.Font, error) {
  * Return all font families that have the given name.
  */
 func GetFontsByName(client *sqlx.DB, name string) ([]*model.Font, error) {
-	var fonts []*model.Font
+	fonts := []*model.Font{}
 
 	err := client.Select(&fonts, `
 		SELECT *
 		FROM FontFamily f
-		WHERE f.name = ?
-	`, name)
+		WHERE f.name LIKE ?
+	`, "%"+name+"%")
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This pull request simply implements the route for getting a font with specific name. It does not lookup the *exact*
name, but rather a name similar to it. What that means is we can type "Comic" and it will pick up "Comic Sans" and "Comic Mono".

## Route

```
GET /api/font?name=<NAME>
```
